### PR TITLE
docs: Link contribution dev setup to main technical section

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,17 +379,8 @@ We welcome contributions! Here's how you can help:
 6. Open a Pull Request with a detailed description
 
 ### 📋 Development Setup
-```bash
-# Clone your fork
-git clone https://github.com/yourusername/pingado.git
-cd pingado
 
-# Install dependencies
-npm install
-
-# Start development
-npm run dev
-```
+For complete development setup instructions, system requirements, and technical details, see the **[🛠️ For Developers](#-for-developers)** section above.
 
 ### 🧪 Testing
 - Test on your target platforms


### PR DESCRIPTION
- Replace duplicate development setup in Contributing section
- Add clear link to 'For Developers' section above
- Avoid documentation duplication and maintenance overhead
- Keep single source of truth for development instructions